### PR TITLE
Add schema for auth, recipes, and comments

### DIFF
--- a/src/schema/auth.ts
+++ b/src/schema/auth.ts
@@ -1,0 +1,28 @@
+import { model, Schema, Model,  Document } from 'mongoose';
+import {ObjectId} from 'mongodb'
+
+interface AuthModel extends Document {
+    email: String,
+    password: String
+}
+
+const AuthSchema: Schema = new Schema({
+        email: {
+            type: String,
+            default: null
+        },
+        password: {
+            type: String,
+            default: null
+        },
+});
+
+
+
+// exporting user model
+export const UserModel = model<AuthModel>('Auth', AuthSchema);
+
+// exporting interface / querying
+export interface IUserModel extends Model<AuthModel> {
+    findByEmail(email, cb);
+}

--- a/src/schema/comments.ts
+++ b/src/schema/comments.ts
@@ -1,0 +1,38 @@
+import { model, Schema, Model,  Document } from 'mongoose';
+import {ObjectId} from 'mongodb'
+
+interface CommentsModel extends Document {
+    author: ObjectId
+    ownerId: ObjectId,
+    rating: Number,
+    body: String
+}
+
+const CommentsSchema: Schema = new Schema({
+        author: {
+            type: ObjectId,
+            default: null
+        },
+        ownerId: {
+            type: ObjectId,
+            default: null
+        },
+        rating: {
+            type: Number,
+            default: 0
+        },
+        body: {
+            type: String,
+            default: null
+        }
+});
+
+
+
+// exporting user model
+export const UserModel = model<CommentsModel>('Auth', CommentsSchema);
+
+// exporting interface / querying
+export interface IUserModel extends Model<CommentsModel> {
+    findByEmail(id, cb);
+}

--- a/src/schema/recipeSchema.ts
+++ b/src/schema/recipeSchema.ts
@@ -1,0 +1,79 @@
+import { model, Schema, Model,  Document } from 'mongoose';
+import {ObjectId, Timestamp} from 'mongodb'
+
+interface RecipeModel extends Document {
+    author: ObjectId
+    toolsNeeded: Object
+    ownerId: ObjectId,
+    ingridients: [Object],
+    instructions: String,
+    recipeImage: String,
+    servingSize: String,
+    type: Number,
+    category: [String],
+    favorite: Number,
+    dateCreated: Timestamp,
+    isPublic: Boolean
+}
+
+const RecipeSchema: Schema = new Schema({
+        author:{
+            type: ObjectId,
+            require: true
+        }, 
+        toolsNeeded: {
+            type: Object,
+            default: {}
+        },
+        ownerId: {
+            type: ObjectId,
+            default: {}
+        },
+        ingridients: {
+            type: String,
+            default: null
+        },
+        instructions: {
+            type: String,
+            default: null
+        },
+        recipeImage: {
+            type: String,
+            default: null
+        },
+        servingSize: {
+            type: String,
+            default: null
+        },
+        type: {
+            type: Number,
+            default: 0
+        },
+        category: {
+            type: Array,
+            default: []
+        },
+        favorite: {
+            type: Number,
+            default: 0
+        },
+        dateCreated: {
+            type: Date,
+            default: Date.now()
+        },
+        isPublic: {
+            type: Boolean,
+            default: false
+        }
+       
+});
+
+
+
+// exporting user model
+export const UserModel = model<RecipeModel>('Recipes', RecipeSchema);
+
+// exporting interface / querying
+export interface IUserModel extends Model<RecipeModel> {
+    findById(id, cb);
+}

--- a/src/schema/userSchema.ts
+++ b/src/schema/userSchema.ts
@@ -3,12 +3,12 @@ import {ObjectId} from 'mongodb'
 
 interface UserModel extends Document {
     author: ObjectId
-    userName: string
-    firstName: string,
-    lastName: string,
-    email: string,
-    profilePic: string,
-    numRecipes: number
+    userName: String
+    firstName: String,
+    lastName: String,
+    email: String,
+    profilePic: String,
+    numRecipes: Number
 }
 
 const UserSchema: Schema = new Schema({
@@ -38,7 +38,7 @@ const UserSchema: Schema = new Schema({
         },
         numRecipes: {
             type: Number,
-            default: null
+            default: 0
         },
 });
 


### PR DESCRIPTION
```Mongo DB Schema
auth {
    email: email
    password: password
}
user {
    _id: 2b04071f-9815-4929-8045-4d62bd79e844,
    username: 'display username',
    firstName: '',
    lastName: '',
    email: ''
    profilePic: ''
    numRecipes: int,
}
recipe {
    _id: 8YC40THf-9815-4929-8045-4d62bd79e844,
    ownerID: 2b04071f-9815-4929-8045-4d62bd79e844, (relates to User _id)
    toolsNeeded?? (crock pot)
    ingredients: [ 
        {
            quantity: '',
            name: ''
        }
    ],
    instructions: '',
    recipeImage: '',
    servingSize: '', range of people
    type: int(1-5)(breakfast, lunch, dinner, dessert)
    category: [ ] list of defined values (Pultry, pork, seafood, Beef, vegetarian, Other )
    difficulty: int (1-5) (So easy meter (how many pans used, time to prepare, clean up time))
    favorites: int (tally of # of times favorited)
    dateCreated: timestamp
    isPublic: bool (if user wants it available)
}

- - - - - Maybe - - - - - 
comment {
    _id: 2b04071f-9815-4929-8045-4d62bd79e844
    ownerID: 949971f-9815-4929-8045-4d62bd79e844 (FK - relates to User UUID)
    rating: int (1-5)
    body: ''
}```